### PR TITLE
Wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ bincode = "1.3"
 bevy = { version = "0.7", default-features = false, features = [
     "render", # need this, or will panic about gpu
     "bevy_winit", # without this, basic example will terminate immediately
-    "wayland" # wayland is the future for linux (and has less deps => faster ci)
+    # "wayland" # wayland is the future for linux (and has less deps => faster ci)
+    "x11" # ... but github actions public runners don't have libxkbcommon :(
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,11 @@ sled = "0.34"
 bincode = "1.3"
 
 [dev-dependencies]
-bevy = { version = "0.7", default-features = false, features = ["render", "bevy_winit"] }
+bevy = { version = "0.7", default-features = false, features = [
+    "render", # need this, or will panic about gpu
+    "bevy_winit", # without this, basic example will terminate immediately
+    "wayland" # wayland is the future for linux (and has less deps => faster ci)
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ sled = "0.34"
 bincode = "1.3"
 
 [dev-dependencies]
-# bevy = { version = "0.7", default-features = false, features = ["render"] }
-bevy = "0.7"
+bevy = { version = "0.7", default-features = false, features = ["render", "bevy_winit"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,21 @@ repository = "https://github.com/johanhelsing/bevy_pkv"
 
 [dependencies]
 bevy = { version = "0.7", default-features = false }
-sled = "0.34"
 thiserror = "1.0"
-bincode = "1.3"
 serde = "1.0"
 
-# todo wasm
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { version = "0.3", default-features = false, features = ["Storage", "Window"] }
+wasm-bindgen = { version = "0.2", default-features = false }
+serde_json = "1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+sled = "0.34"
+bincode = "1.3"
+
+[dev-dependencies]
+# bevy = { version = "0.7", default-features = false, features = ["render"] }
+bevy = "0.7"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+console_error_panic_hook = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,11 @@ bevy = "0.7"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1"
+easybench-wasm = "0.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.3", features = ["html_reports"] }
+
+[[bench]]
+name = "inserts"
+harness = false

--- a/README.md
+++ b/README.md
@@ -14,19 +14,15 @@ choice, but it will do for now.
 It currently creates a single global key value store when the plugin is
 initialized.
 
-## TODO
-
-- Wasm implementation based on localstorage api
-- Different scopes?
-
 ## Usage
 
 Add the plugin to your app
 
 ```rust
-App::build()
+App::new()
     .add_plugins(DefaultPlugins)
-    .add_plugin(PkvPlugin);
+    .add_plugin(PkvPlugin)
+    .run();
 ```
 
 Use it in a system:

--- a/benches/inserts.rs
+++ b/benches/inserts.rs
@@ -1,0 +1,85 @@
+use bevy_pkv::PkvStore;
+
+fn insert_values(store: &mut PkvStore, pairs: &Vec<(String, String)>) {
+    for (key, value) in pairs {
+        store.set::<String>(key, value).unwrap();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use super::insert_values;
+    use bevy_pkv::PkvStore;
+    use criterion::{criterion_group, BatchSize, Criterion};
+
+    fn insert_benchmark(c: &mut Criterion) {
+        c.bench_function("insert 100", |b| {
+            b.iter_batched(
+                || {
+                    let store = PkvStore::default();
+                    let values = (0..100).map(|i| (i.to_string(), i.to_string())).collect();
+                    // todo: clear the store here
+                    (store, values)
+                },
+                |(mut store, pairs)| insert_values(&mut store, &pairs),
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    criterion_group!(benches, insert_benchmark);
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use super::insert_values;
+    use bevy_pkv::PkvStore;
+    use easybench_wasm::bench_env;
+    use web_sys::console;
+
+    // Easy bench clones the environment, but store doesn't implement clone
+    struct HackStore(PkvStore);
+
+    impl Clone for HackStore {
+        fn clone(&self) -> Self {
+            // todo: clear store as well
+            Self(Default::default())
+        }
+    }
+
+    pub fn main() {
+        console::log_1(&"Hi".to_string().into());
+        {
+            let values: Vec<(String, String)> =
+                (0..100).map(|i| (i.to_string(), i.to_string())).collect();
+            let env = (HackStore(PkvStore::default()), values);
+            console::log_1(
+                &format!(
+                    "insert 100: {}",
+                    bench_env(env, |(store, values)| insert_values(&mut store.0, values)),
+                )
+                .into(),
+            );
+        }
+        {
+            let values: Vec<(String, String)> =
+                (0..1000).map(|i| (i.to_string(), i.to_string())).collect();
+            let env = (HackStore(PkvStore::default()), values);
+            console::log_1(
+                &format!(
+                    "insert 1000: {}",
+                    bench_env(env, |(store, values)| insert_values(&mut store.0, values)),
+                )
+                .into(),
+            );
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    wasm::main()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+criterion::criterion_main!(native::benches);

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,7 +7,7 @@ struct User {
     name: String,
 }
 
-fn setup(mut pkv: ResMut<PkvStore>) {
+fn setup(mut pkv: NonSendMut<PkvStore>) {
     // strings
     if let Ok(username) = pkv.get::<String>("username") {
         info!("Welcome back {username}");
@@ -32,6 +32,10 @@ fn setup(mut pkv: ResMut<PkvStore>) {
 }
 
 fn main() {
+    // When building for WASM, print panics to the browser console
+    #[cfg(target_arch = "wasm32")]
+    console_error_panic_hook::set_once();
+
     App::new()
         .add_plugin(PkvPlugin)
         .add_plugins(DefaultPlugins)

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,7 +7,7 @@ struct User {
     name: String,
 }
 
-fn setup(mut pkv: NonSendMut<PkvStore>) {
+fn setup(mut pkv: ResMut<PkvStore>) {
     // strings
     if let Ok(username) = pkv.get::<String>("username") {
         info!("Welcome back {username}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,132 +11,55 @@ impl Plugin for PkvPlugin {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Debug)]
-pub struct PkvStore {
-    db: sled::Db,
+trait StoreImpl<GetError, SetError> {
+    fn set_string(&mut self, key: &str, value: &str) -> Result<(), SetError> {
+        self.set(key, &value.to_string())
+    }
+    fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T, GetError>;
+    fn set<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), SetError>;
 }
+
+#[cfg(target_arch = "wasm32")]
+mod local_storage_store;
+
+#[cfg(target_arch = "wasm32")]
+pub use local_storage_store::{GetError, SetError};
+
+#[cfg(not(target_arch = "wasm32"))]
+mod sled_store;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use sled_store::{GetError, SetError};
 
 /// Main resource for setting/getting values
 ///
 /// Automatically inserted when adding `PkvPlugin`
+#[derive(Debug, Default)]
 #[cfg(target_arch = "wasm32")]
-#[derive(Debug)]
-pub struct PkvStore {}
-
-#[allow(clippy::derivable_impls)]
-impl Default for PkvStore {
-    // todo: maybe consider not exposing this, so people are not tempted
-    // to try to manually initialize stores?
-    fn default() -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let db = sled::open("bevy_pkv.sled").expect("Failed to init key value store");
-            Self { db }
-        }
-        #[cfg(target_arch = "wasm32")]
-        Self {}
-    }
+pub struct PkvStore {
+    inner: local_storage_store::LocalStorageStore,
 }
 
+#[derive(Debug, Default)]
 #[cfg(not(target_arch = "wasm32"))]
-#[derive(thiserror::Error, Debug)]
-pub enum SetError {
-    #[error("Sled error")]
-    Sled(#[from] sled::Error),
-    #[error("Bincode error")]
-    Bincode(#[from] bincode::Error),
-}
-
-#[cfg(target_arch = "wasm32")]
-#[derive(thiserror::Error, Debug)]
-pub enum SetError {
-    #[error("JavaScript error from setItem")]
-    SetItem(wasm_bindgen::JsValue),
-    #[error("Error serializing as json")]
-    Json(#[from] serde_json::Error),
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(thiserror::Error, Debug)]
-pub enum GetError {
-    #[error("Sled error")]
-    Sled(#[from] sled::Error),
-    #[error("Bincode error")]
-    Bincode(#[from] bincode::Error),
-    #[error("No value found for the given key")]
-    NotFound,
-}
-
-#[cfg(target_arch = "wasm32")]
-#[derive(thiserror::Error, Debug)]
-pub enum GetError {
-    #[error("No value found for the given key")]
-    NotFound,
-    #[error("JavaScript error from getItem")]
-    GetItem(wasm_bindgen::JsValue),
+pub struct PkvStore {
+    inner: sled_store::SledStore,
 }
 
 impl PkvStore {
-    #[cfg(target_arch = "wasm32")]
-    fn storage(&self) -> web_sys::Storage {
-        #[cfg(target_arch = "wasm32")]
-        web_sys::window()
-            .expect("No window")
-            .local_storage()
-            .expect("Failed to get local storage")
-            .expect("No local storage")
-    }
-
     /// Serialize and store the value
     pub fn set<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), SetError> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let bytes = bincode::serialize(value)?;
-            self.db.insert(key, bytes)?;
-            Ok(())
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            let json = serde_json::to_string(value)?;
-            let storage = self.storage();
-            storage.set_item(key, &json).map_err(SetError::SetItem)?;
-            Ok(())
-        }
+        self.inner.set(key, value)
     }
 
     /// More or less the same as set::<String>, but can take a &str
     pub fn set_string(&mut self, key: &str, value: &str) -> Result<(), SetError> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let bytes = bincode::serialize(value)?;
-            self.db.insert(key, bytes)?;
-            Ok(())
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            let storage = self.storage();
-            storage.set_item(key, value).map_err(SetError::SetItem)?;
-            Ok(())
-        }
+        self.inner.set_string(key, value)
     }
 
     /// Get the value for the given key
     /// returns Err(GetError::NotFound) if the key does not exist in the key value store.
     pub fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T, GetError> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let bytes = self.db.get(key)?.ok_or(GetError::NotFound)?;
-            let value = bincode::deserialize(&bytes)?;
-            Ok(value)
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            let storage = self.storage();
-            let entry = storage.get_item(key).map_err(GetError::GetItem)?;
-            let json = entry.as_ref().ok_or(GetError::NotFound)?;
-            let value: T = serde_json::from_str(json).unwrap();
-            Ok(value)
-        }
+        self.inner.get(key)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use serde::{de::DeserializeOwned, Serialize};
 
+/// Main plugin for the bevy_pkv crate
 #[derive(Default)]
 pub struct PkvPlugin;
 
@@ -16,12 +17,17 @@ pub struct PkvStore {
     db: sled::Db,
 }
 
+/// Main resource for setting/getting values
+///
+/// Automatically inserted when adding `PkvPlugin`
 #[cfg(target_arch = "wasm32")]
 #[derive(Debug)]
 pub struct PkvStore {}
 
 #[allow(clippy::derivable_impls)]
 impl Default for PkvStore {
+    // todo: maybe consider not exposing this, so people are not tempted
+    // to try to manually initialize stores?
     fn default() -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         {

--- a/src/local_storage_store.rs
+++ b/src/local_storage_store.rs
@@ -19,6 +19,8 @@ pub enum SetError {
 #[derive(Debug, Default)]
 pub struct LocalStorageStore;
 
+pub use LocalStorageStore as InnerStore;
+
 impl LocalStorageStore {
     fn storage(&self) -> web_sys::Storage {
         web_sys::window()
@@ -29,7 +31,10 @@ impl LocalStorageStore {
     }
 }
 
-impl StoreImpl<GetError, SetError> for LocalStorageStore {
+impl StoreImpl for LocalStorageStore {
+    type GetError = GetError;
+    type SetError = SetError;
+
     fn set_string(&mut self, key: &str, value: &str) -> Result<(), SetError> {
         let storage = self.storage();
         storage.set_item(key, value).map_err(SetError::SetItem)?;

--- a/src/local_storage_store.rs
+++ b/src/local_storage_store.rs
@@ -1,0 +1,53 @@
+use crate::StoreImpl;
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetError {
+    #[error("No value found for the given key")]
+    NotFound,
+    #[error("JavaScript error from getItem")]
+    GetItem(wasm_bindgen::JsValue),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum SetError {
+    #[error("JavaScript error from setItem")]
+    SetItem(wasm_bindgen::JsValue),
+    #[error("Error serializing as json")]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Default)]
+pub struct LocalStorageStore;
+
+impl LocalStorageStore {
+    fn storage(&self) -> web_sys::Storage {
+        web_sys::window()
+            .expect("No window")
+            .local_storage()
+            .expect("Failed to get local storage")
+            .expect("No local storage")
+    }
+}
+
+impl StoreImpl<GetError, SetError> for LocalStorageStore {
+    fn set_string(&mut self, key: &str, value: &str) -> Result<(), SetError> {
+        let storage = self.storage();
+        storage.set_item(key, value).map_err(SetError::SetItem)?;
+        Ok(())
+    }
+
+    fn get<T: serde::de::DeserializeOwned>(&self, key: &str) -> Result<T, GetError> {
+        let storage = self.storage();
+        let entry = storage.get_item(key).map_err(GetError::GetItem)?;
+        let json = entry.as_ref().ok_or(GetError::NotFound)?;
+        let value: T = serde_json::from_str(json).unwrap();
+        Ok(value)
+    }
+
+    fn set<T: serde::Serialize>(&mut self, key: &str, value: &T) -> Result<(), SetError> {
+        let json = serde_json::to_string(value)?;
+        let storage = self.storage();
+        storage.set_item(key, &json).map_err(SetError::SetItem)?;
+        Ok(())
+    }
+}

--- a/src/local_storage_store.rs
+++ b/src/local_storage_store.rs
@@ -1,5 +1,10 @@
 use crate::StoreImpl;
 
+#[derive(Debug, Default)]
+pub struct LocalStorageStore;
+
+pub use LocalStorageStore as InnerStore;
+
 #[derive(thiserror::Error, Debug)]
 pub enum GetError {
     #[error("No value found for the given key")]
@@ -15,11 +20,6 @@ pub enum SetError {
     #[error("Error serializing as json")]
     Json(#[from] serde_json::Error),
 }
-
-#[derive(Debug, Default)]
-pub struct LocalStorageStore;
-
-pub use LocalStorageStore as InnerStore;
 
 impl LocalStorageStore {
     fn storage(&self) -> web_sys::Storage {

--- a/src/sled_store.rs
+++ b/src/sled_store.rs
@@ -1,0 +1,61 @@
+use crate::StoreImpl;
+use serde::{de::DeserializeOwned, Serialize};
+
+#[derive(Debug)]
+pub struct SledStore {
+    db: sled::Db,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetError {
+    #[error("Sled error")]
+    Sled(#[from] sled::Error),
+    #[error("Bincode error")]
+    Bincode(#[from] bincode::Error),
+    #[error("No value found for the given key")]
+    NotFound,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum SetError {
+    #[error("Sled error")]
+    Sled(#[from] sled::Error),
+    #[error("Bincode error")]
+    Bincode(#[from] bincode::Error),
+}
+
+impl Default for SledStore {
+    // todo: maybe consider not exposing this, so people are not tempted
+    // to try to manually initialize stores?
+    fn default() -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let db = sled::open("bevy_pkv.sled").expect("Failed to init key value store");
+            Self { db }
+        }
+    }
+}
+
+impl StoreImpl<GetError, SetError> for SledStore {
+    /// Serialize and store the value
+    fn set<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), SetError> {
+        let bytes = bincode::serialize(value)?;
+        self.db.insert(key, bytes)?;
+        Ok(())
+    }
+
+    /// More or less the same as set::<String>, but can take a &str
+    fn set_string(&mut self, key: &str, value: &str) -> Result<(), SetError> {
+        let bytes = bincode::serialize(value)?;
+        self.db.insert(key, bytes)?;
+        Ok(())
+    }
+
+    /// Get the value for the given key
+    /// returns Err(GetError::NotFound) if the key does not exist in the key value store.
+    fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T, GetError> {
+        let bytes = self.db.get(key)?.ok_or(GetError::NotFound)?;
+        let value = bincode::deserialize(&bytes)?;
+        Ok(value)
+    }
+}


### PR DESCRIPTION
~~The store is now a NonSend resource... which is a bit unfortunate, not
sure what we can do about that... Maybe we can make it a special system param that is nonsend on wasm only?~~

~~The implementation is a bit messy now... Probably would be a good idea to move platform specific implementations into separate files...~~

The error types are currently different based on platform... Maybe not ideal?