### PR TITLE
PkvStore Resource fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/johanhelsing/bevy_pkv"
 [dependencies]
 thiserror = "1.0"
 serde = "1.0"
-bevy_ecs = "0.9.0" # we need this to the derive Resource for PkvStore
+bevy_ecs = "0.9.0" # we need for deriving Resource in PkvStore
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", default-features = false, features = ["Storage", "Window"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_pkv"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Johan Helsing <johanhelsing@gmail.com>"]
@@ -12,6 +12,7 @@ repository = "https://github.com/johanhelsing/bevy_pkv"
 [dependencies]
 thiserror = "1.0"
 serde = "1.0"
+bevy_ecs = "0.9.0" # we need this to the derive Resource for PkvStore
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", default-features = false, features = ["Storage", "Window"] }
@@ -24,11 +25,11 @@ rmp-serde = "1.1"
 directories = "4.0"
 
 [dev-dependencies]
-bevy = { version = "0.7", default-features = false, features = [
+bevy = { version = "0.9", default-features = false, features = [
     "render", # need this, or will panic about gpu
     "bevy_winit", # without this, basic example will terminate immediately
     # "wayland" # wayland is the future for linux (and has less deps => faster ci)
-    "x11" # ... but github actions public runners don't have libxkbcommon :(
+    "x11", # ... but github actions public runners don't have libxkbcommon :(
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ thiserror = "1.0"
 serde = "1.0"
 bevy_ecs = "0.9.0" # we need for deriving Resource in PkvStore
 
+[features]
+default = ["bevy"]
+bevy = []
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", default-features = false, features = ["Storage", "Window"] }
 wasm-bindgen = { version = "0.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ I intend to support the `main` branch of Bevy in the `bevy-main` branch.
 
 |bevy|bevy\_pkv|
 |---|---|
-|any|0.5, main|
+|0.8|0.6, main|
+|0.8|0.5|
 |0.7|0.2, 0.3, 0.4|
 |0.6|0.1|
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ I intend to support the `main` branch of Bevy in the `bevy-main` branch.
 
 |bevy|bevy\_pkv|
 |---|---|
-|0.8|0.6, main|
+|0.9|0.6, main|
 |0.8|0.5|
 |0.7|0.2, 0.3, 0.4|
 |0.6|0.1|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{de::DeserializeOwned, Serialize};
+use bevy_ecs::prelude::Resource;
 
 trait StoreImpl {
     type GetError;
@@ -30,7 +31,7 @@ pub use backend::{GetError, SetError};
 /// Main resource for setting/getting values
 ///
 /// Automatically inserted when adding `PkvPlugin`
-#[derive(Debug)]
+#[derive(Debug, Resource)]
 pub struct PkvStore {
     inner: backend::InnerStore,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::{de::DeserializeOwned, Serialize};
-use bevy_ecs::prelude::Resource;
+#[cfg(feature = "bevy")] use bevy_ecs::prelude::Resource;
+
 
 trait StoreImpl {
     type GetError;
@@ -31,7 +32,8 @@ pub use backend::{GetError, SetError};
 /// Main resource for setting/getting values
 ///
 /// Automatically inserted when adding `PkvPlugin`
-#[derive(Debug, Resource)]
+#[derive(Debug)]
+#[cfg_attr(feature = "bevy", derive(Resource))]
 pub struct PkvStore {
     inner: backend::InnerStore,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 use serde::{de::DeserializeOwned, Serialize};
-#[cfg(feature = "bevy")] use bevy_ecs::prelude::Resource;
-
 
 trait StoreImpl {
     type GetError;
@@ -33,7 +31,7 @@ pub use backend::{GetError, SetError};
 ///
 /// Automatically inserted when adding `PkvPlugin`
 #[derive(Debug)]
-#[cfg_attr(feature = "bevy", derive(Resource))]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Resource))]
 pub struct PkvStore {
     inner: backend::InnerStore,
 }


### PR DESCRIPTION
My attempt at fixing PkvStore not being a resource. Not sure if it is possible to add something smaller than bevy_ecs to dependencies. The error is `PkvStore: bevy::prelude::Resource is not satisfied` for `Res<PkvStore>`, `ResMut<PkvStore>`, ect.