### PR TITLE
feat: RocksDB Backend Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,16 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run cargo check
+      - name: cargo check sled
         uses: actions-rs/cargo@v1
         with:
           command: check
+
+      - name: cargo check rocksdb
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --features rocksdb
 
   test:
     name: Test Suite
@@ -40,10 +46,16 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run cargo test
+      - name: cargo test sled
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: cargo test rocksdb
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features rocksdb
 
   lints:
     name: Lints
@@ -60,13 +72,13 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Run cargo fmt
+      - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
-      - name: Run cargo clippy
+      - name: cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,11 @@ criterion = { version = "0.4", features = ["html_reports"] }
 [[bench]]
 name = "inserts"
 harness = false
+
+[[example]]
+name = "basic"
+required-features = ["bevy"]
+
+[[example]]
+name = "migration"
+required-features = ["bevy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,15 @@ repository = "https://github.com/johanhelsing/bevy_pkv"
 [dependencies]
 thiserror = "1.0"
 serde = "1.0"
-rocksdb = "0.20.1"
+rocksdb = { version = "0.20", optional = true }
+sled = { version = "0.34", optional = true }
 bevy_ecs = "0.10" # we need for deriving Resource in PkvStore
 
 [features]
 default = ["bevy"]
 bevy = []
-rocksdb = []
+rocksdb = ["dep:rocksdb"]
+sled = ["dep:sled"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", default-features = false, features = ["Storage", "Window"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ thiserror = "1.0"
 serde = "1.0"
 rocksdb = { version = "0.20", optional = true }
 sled = { version = "0.34", optional = true }
-bevy_ecs = "0.10" # we need for deriving Resource in PkvStore
+bevy_ecs = { version = "0.10", optional = true } # we need for deriving Resource in PkvStore
 
 [features]
-default = ["bevy"]
-bevy = []
+default = ["bevy", "sled"]
+bevy = ["dep:bevy_ecs"]
 rocksdb = ["dep:rocksdb"]
 sled = ["dep:sled"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ repository = "https://github.com/johanhelsing/bevy_pkv"
 [dependencies]
 thiserror = "1.0"
 serde = "1.0"
-rocksdb = { version = "0.20", optional = true }
-sled = { version = "0.34", optional = true }
 bevy_ecs = { version = "0.10", optional = true } # we need for deriving Resource in PkvStore
 
 [features]
@@ -28,12 +26,16 @@ wasm-bindgen = { version = "0.2", default-features = false }
 serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-sled = "0.34"
+rocksdb = { version = "0.20", optional = true }
+sled = { version = "0.34", optional = true }
 rmp-serde = "1.1"
 directories = "4.0"
 
 [dev-dependencies]
 bevy = { version = "0.10", default-features = false }
+
+[build-dependencies]
+cfg_aliases = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ repository = "https://github.com/johanhelsing/bevy_pkv"
 [dependencies]
 thiserror = "1.0"
 serde = "1.0"
+rocksdb = "0.20.1"
 bevy_ecs = "0.10" # we need for deriving Resource in PkvStore
 
 [features]
 default = ["bevy"]
 bevy = []
+rocksdb = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", default-features = false, features = ["Storage", "Window"] }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Currently, the Bevy dependency is optional, so it may be used in other games/app
 Add a store resource to your app
 
 ```rust no_run
+# #[cfg(feature = "bevy")] { // ignore this line
 use bevy::prelude::*;
 use bevy_pkv::PkvStore;
 
@@ -26,6 +27,7 @@ App::new()
     // ...insert systems etc.
     .run();
 }
+# }
 ```
 
 This will create or load a store in the appropriate location for your system, and make it available to bevy systems:

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    cfg_aliases! {
+        wasm: { target_arch = "wasm32" },
+        rocksdb_backend: { all(feature = "rocksdb", not(wasm)) },
+        sled_backend: { all(feature = "sled", not(wasm)) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+#[cfg(all(rocksdb_backend, sled_backend))]
+compile_error!("the \"rocksdb\" and \"sled\" features may not be enabled at the same time");
+
+#[cfg(not(any(rocksdb_backend, sled_backend, wasm)))]
+compile_error!("either the \"rocksdb\" or \"sled\" feature must be enabled on native");
+
 use serde::{de::DeserializeOwned, Serialize};
 
 trait StoreImpl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,26 +15,22 @@ trait StoreImpl {
     fn clear(&mut self) -> Result<(), Self::SetError>;
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(wasm)]
 mod local_storage_store;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(wasm)]
 use local_storage_store::{self as backend};
 
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(feature = "rocksdb"))]
+#[cfg(sled_backend)]
 mod sled_store;
 
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(feature = "rocksdb"))]
+#[cfg(sled_backend)]
 use sled_store::{self as backend};
 
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg(feature = "rocksdb")]
+#[cfg(rocksdb_backend)]
 mod rocksdb_store;
 
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg(feature = "rocksdb")]
+#[cfg(rocksdb_backend)]
 use rocksdb_store::{self as backend};
 
 // todo: Look into unifying these types?

--- a/src/rocksdb_store.rs
+++ b/src/rocksdb_store.rs
@@ -1,0 +1,110 @@
+use crate::{StoreConfig, StoreImpl};
+use directories::ProjectDirs;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{path::Path, str::Utf8Error};
+
+#[derive(Debug)]
+pub struct RocksDBStore {
+    db: rocksdb::DB,
+}
+
+pub use RocksDBStore as InnerStore;
+
+/// Errors that can occur during `PkvStore::get`
+#[derive(thiserror::Error, Debug)]
+pub enum GetError {
+    /// An internal error from the rocksdb crate
+    #[error("Rocksdb error")]
+    Rocksdb(#[from] rocksdb::Error),
+    /// Error when deserializing the value
+    #[error("MessagePack deserialization error")]
+    MessagePack(#[from] rmp_serde::decode::Error),
+    /// The value for the given key was not found
+    #[error("No value found for the given key")]
+    NotFound,
+}
+
+/// Errors that can occur during `PkvStore::set`
+#[derive(thiserror::Error, Debug)]
+pub enum SetError {
+    /// An internal error from the rocksdb crate
+    #[error("Rocksdb error")]
+    Rocksdb(#[from] rocksdb::Error),
+    /// Error when serializing the value
+    #[error("MessagePack serialization error")]
+    MessagePack(#[from] rmp_serde::encode::Error),
+    /// Invalid utf8 key name
+    #[error("Invalid RocksDB key name error")]
+    RocksdbKeyName(#[from] Utf8Error),
+}
+
+impl RocksDBStore {
+    pub(crate) fn new(config: &StoreConfig) -> Self {
+        let mut options = rocksdb::Options::default();
+        options.set_error_if_exists(false);
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+
+        let dirs = ProjectDirs::from(
+            config.qualifier.as_deref().unwrap_or(""),
+            &config.organization,
+            &config.application,
+        );
+
+        let parent_dir = match dirs.as_ref() {
+            Some(dirs) => dirs.data_dir(),
+            None => Path::new("."), // todo: maybe warn?
+        };
+
+        let db_path = parent_dir.join("bevy_rocksdb_pkv");
+
+        let db = rocksdb::DB::open(&options, db_path).expect("Failed to init key value store");
+
+        Self { db }
+    }
+}
+
+impl StoreImpl for RocksDBStore {
+    type GetError = GetError;
+    type SetError = SetError;
+
+    /// Serialize and store the value
+    fn set<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), Self::SetError> {
+        let mut serializer = rmp_serde::Serializer::new(Vec::new()).with_struct_map();
+        value.serialize(&mut serializer)?;
+        self.db.put(&key, serializer.into_inner())?;
+
+        Ok(())
+    }
+
+    /// More or less the same as set::<String>, but can take a &str
+    fn set_string(&mut self, key: &str, value: &str) -> Result<(), Self::SetError> {
+        let bytes = rmp_serde::to_vec(value)?;
+        self.db.put(key, bytes)?;
+
+        Ok(())
+    }
+
+    /// Get the value for the given key
+    /// returns Err(GetError::NotFound) if the key does not exist in the key value store.
+    fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T, Self::GetError> {
+        let bytes = self.db.get(key)?.ok_or(Self::GetError::NotFound)?;
+        let value = rmp_serde::from_slice(&bytes)?;
+        Ok(value)
+    }
+
+    /// Clear all keys and their values
+    /// The RocksDB adapter uses an iterator to achieve this, unlike sled
+    fn clear(&mut self) -> Result<(), Self::SetError> {
+        let kv_iter = self.db.iterator(rocksdb::IteratorMode::Start);
+
+        for kv in kv_iter {
+            let result = kv?;
+            let key = result.0;
+            let key = std::str::from_utf8(&key)?;
+            self.db.delete(key)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/rocksdb_store.rs
+++ b/src/rocksdb_store.rs
@@ -99,8 +99,7 @@ impl StoreImpl for RocksDBStore {
         let kv_iter = self.db.iterator(rocksdb::IteratorMode::Start);
 
         for kv in kv_iter {
-            let result = kv?;
-            let key = result.0;
+            let (key, _) = kv?;
             let key = std::str::from_utf8(&key)?;
             self.db.delete(key)?;
         }

--- a/src/rocksdb_store.rs
+++ b/src/rocksdb_store.rs
@@ -1,7 +1,7 @@
 use crate::{StoreConfig, StoreImpl};
 use directories::ProjectDirs;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{path::Path, str::Utf8Error};
+use std::path::Path;
 
 #[derive(Debug)]
 pub struct RocksDBStore {
@@ -33,9 +33,6 @@ pub enum SetError {
     /// Error when serializing the value
     #[error("MessagePack serialization error")]
     MessagePack(#[from] rmp_serde::encode::Error),
-    /// Invalid utf8 key name
-    #[error("Invalid RocksDB key name error")]
-    RocksdbKeyName(#[from] Utf8Error),
 }
 
 impl RocksDBStore {
@@ -100,7 +97,6 @@ impl StoreImpl for RocksDBStore {
 
         for kv in kv_iter {
             let (key, _) = kv?;
-            let key = std::str::from_utf8(&key)?;
             self.db.delete(key)?;
         }
 

--- a/src/rocksdb_store.rs
+++ b/src/rocksdb_store.rs
@@ -69,7 +69,7 @@ impl StoreImpl for RocksDBStore {
     fn set<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), Self::SetError> {
         let mut serializer = rmp_serde::Serializer::new(Vec::new()).with_struct_map();
         value.serialize(&mut serializer)?;
-        self.db.put(&key, serializer.into_inner())?;
+        self.db.put(key, serializer.into_inner())?;
 
         Ok(())
     }


### PR DESCRIPTION
This adds support for **RocksDB** as an alternative backend for non-wasm based environments. The default backend, **Sled**, is still used unless `rocksdb` is enabled as a feature.

The test for the `clear` function was also altered to cover the way the **RocksDB** adapter implements it.

Closes #20 