### PR TITLE
made set and get take AsRef<str>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,4 @@ required-features = ["bevy"]
 
 [[example]]
 name = "enumkeys"
+required-features = ["bevy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ directories = "5.0"
 
 [dev-dependencies]
 bevy = { version = "0.10", default-features = false }
+strum_macros = "*"
 
 [build-dependencies]
 cfg_aliases = "0.1"
@@ -56,3 +57,6 @@ required-features = ["bevy"]
 [[example]]
 name = "migration"
 required-features = ["bevy"]
+
+[[example]]
+name = "enumkeys"

--- a/examples/enumkeys.rs
+++ b/examples/enumkeys.rs
@@ -38,7 +38,7 @@ fn main() {
     console_error_panic_hook::set_once();
 
     App::new()
-        .insert_resource(PkvStore::new("BevyPkv", "BasicExample"))
+        .insert_resource(PkvStore::new("BevyPkv", "EnumExample"))
         .add_plugins(MinimalPlugins)
         .add_plugin(LogPlugin::default())
         .add_startup_system(setup)

--- a/examples/enumkeys.rs
+++ b/examples/enumkeys.rs
@@ -1,0 +1,50 @@
+use bevy::{log::LogPlugin, prelude::*};
+use bevy_pkv::PkvStore;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct User {
+    name: String,
+}
+
+fn setup(mut pkv: ResMut<PkvStore>) {
+    // strings
+    if let Ok(username) = pkv.get::<String>("username") {
+        info!("Welcome back {username}");
+    } else {
+        pkv.set_string("username", "alice")
+            .expect("failed to store username");
+
+        // alternatively, using the slightly less efficient generic api:
+        pkv.set("username", &"alice".to_string())
+            .expect("failed to store username");
+    }
+
+    // serde types
+    if let Ok(user) = pkv.get::<User>(PKVKeys::User) {
+        info!("Welcome back {}", user.name);
+    } else {
+        let user = User {
+            name: "bob".to_string(),
+        };
+        pkv.set(PKVKeys::User, &user).expect("failed to store User struct");
+    }
+}
+
+fn main() {
+    // When building for WASM, print panics to the browser console
+    #[cfg(target_arch = "wasm32")]
+    console_error_panic_hook::set_once();
+
+    App::new()
+        .insert_resource(PkvStore::new("BevyPkv", "BasicExample"))
+        .add_plugins(MinimalPlugins)
+        .add_plugin(LogPlugin::default())
+        .add_startup_system(setup)
+        .run();
+}
+
+#[derive(strum_macros::AsRefStr)]
+enum PKVKeys {
+    User,
+}

--- a/examples/enumkeys.rs
+++ b/examples/enumkeys.rs
@@ -9,25 +9,25 @@ struct User {
 
 fn setup(mut pkv: ResMut<PkvStore>) {
     // strings
-    if let Ok(username) = pkv.get::<String>("username") {
+    if let Ok(username) = pkv.get::<String>(PkvKeys::UserName) {
         info!("Welcome back {username}");
     } else {
-        pkv.set_string("username", "alice")
+        pkv.set_string(PkvKeys::UserName, "alice")
             .expect("failed to store username");
 
         // alternatively, using the slightly less efficient generic api:
-        pkv.set("username", &"alice".to_string())
+        pkv.set(PkvKeys::UserName, &"alice".to_string())
             .expect("failed to store username");
     }
 
     // serde types
-    if let Ok(user) = pkv.get::<User>(PKVKeys::User) {
+    if let Ok(user) = pkv.get::<User>(PkvKeys::User) {
         info!("Welcome back {}", user.name);
     } else {
         let user = User {
             name: "bob".to_string(),
         };
-        pkv.set(PKVKeys::User, &user)
+        pkv.set(PkvKeys::User, &user)
             .expect("failed to store User struct");
     }
 }
@@ -46,6 +46,7 @@ fn main() {
 }
 
 #[derive(strum_macros::AsRefStr)]
-enum PKVKeys {
+enum PkvKeys {
     User,
+    UserName,
 }

--- a/examples/enumkeys.rs
+++ b/examples/enumkeys.rs
@@ -27,7 +27,8 @@ fn setup(mut pkv: ResMut<PkvStore>) {
         let user = User {
             name: "bob".to_string(),
         };
-        pkv.set(PKVKeys::User, &user).expect("failed to store User struct");
+        pkv.set(PKVKeys::User, &user)
+            .expect("failed to store User struct");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,8 @@ impl PkvStore {
     }
 
     /// Serialize and store the value
-    pub fn set<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), SetError> {
-        self.inner.set(key, value)
+    pub fn set<T: Serialize>(&mut self, key: impl AsRef<str>, value: &T) -> Result<(), SetError> {
+        self.inner.set(key.as_ref(), value)
     }
 
     /// More or less the same as set::<String>, but can take a &str
@@ -114,8 +114,8 @@ impl PkvStore {
 
     /// Get the value for the given key
     /// returns Err(GetError::NotFound) if the key does not exist in the key value store.
-    pub fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T, GetError> {
-        self.inner.get(key)
+    pub fn get<T: DeserializeOwned>(&self, key: impl AsRef<str>) -> Result<T, GetError> {
+        self.inner.get(key.as_ref())
     }
 
     /// Clear all key values data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,8 @@ impl PkvStore {
     }
 
     /// More or less the same as set::<String>, but can take a &str
-    pub fn set_string(&mut self, key: &str, value: &str) -> Result<(), SetError> {
-        self.inner.set_string(key, value)
+    pub fn set_string(&mut self, key: impl AsRef<str>, value: &str) -> Result<(), SetError> {
+        self.inner.set_string(key.as_ref(), value)
     }
 
     /// Get the value for the given key


### PR DESCRIPTION
made the set and get methods on the PKVStore take AsRef<str> so that the user can use types the impl AsRef<str> as an alternative to just &str, this means you can use an enum and strum to quickly make a set of keys and no have to worry about spelling mistakes, this also doesn't lock the user into a single type like a generic would and shouldn't break and currently used cases outside of people using calls to into() or as_ref() to get the same behaviour