### PR TITLE
Update to Bevy 0.11-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/johanhelsing/bevy_pkv"
 [dependencies]
 thiserror = "1.0"
 serde = "1.0"
-bevy_ecs = { version = "0.10", optional = true } # we need for deriving Resource in PkvStore
+bevy_ecs = { git = "https://github.com/bevyengine/bevy", optional = true } # we need for deriving Resource in PkvStore
 
 [features]
 default = ["bevy", "sled"]
@@ -32,7 +32,7 @@ rmp-serde = "1.1"
 directories = "5.0"
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false }
 strum_macros = "*"
 
 [build-dependencies]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -40,6 +40,6 @@ fn main() {
         .insert_resource(PkvStore::new("BevyPkv", "BasicExample"))
         .add_plugins(MinimalPlugins)
         .add_plugin(LogPlugin::default())
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }

--- a/examples/enumkeys.rs
+++ b/examples/enumkeys.rs
@@ -41,7 +41,7 @@ fn main() {
         .insert_resource(PkvStore::new("BevyPkv", "EnumExample"))
         .add_plugins(MinimalPlugins)
         .add_plugin(LogPlugin::default())
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/migration.rs
+++ b/examples/migration.rs
@@ -66,6 +66,6 @@ fn main() {
         .insert_resource(PkvStore::new("BevyPkv", "MigrationExample"))
         .add_plugins(MinimalPlugins)
         .add_plugin(LogPlugin::default())
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }


### PR DESCRIPTION
Small updates to support bevy main. There isn't much to change really, just the Cargo.toml and update the examples to the new system syntax (bevyengine/bevy#8079). This should target a `bevy-main` branch, so I'm marking it as a draft. If there are any further changes I'll update this.