### PR TITLE
Upgrade to bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/johanhelsing/bevy_pkv"
 [dependencies]
 thiserror = "1.0"
 serde = "1.0"
-bevy_ecs = { version = "0.10", optional = true } # we need for deriving Resource in PkvStore
+bevy_ecs = { version = "0.11", optional = true } # we need for deriving Resource in PkvStore
 
 [features]
 default = ["bevy", "redb"]
@@ -34,7 +34,7 @@ directories = "5.0"
 redb = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.11", default-features = false }
 strum_macros = "*"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_pkv"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Johan Helsing <johanhelsing@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ I intend to support the `main` branch of Bevy in the `bevy-main` branch.
 
 |bevy|bevy\_pkv|
 |----|---|
-|0.10|0.7, main|
+|0.11|0.8, main|
+|0.10|0.7|
 |0.9 |0.6|
 |0.8 |0.5|
 |0.7 |0.2, 0.3, 0.4|

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -39,7 +39,7 @@ fn main() {
     App::new()
         .insert_resource(PkvStore::new("BevyPkv", "BasicExample"))
         .add_plugins(MinimalPlugins)
-        .add_plugin(LogPlugin::default())
-        .add_startup_system(setup)
+        .add_plugins(LogPlugin::default())
+        .add_systems(Startup, setup)
         .run();
 }

--- a/examples/enumkeys.rs
+++ b/examples/enumkeys.rs
@@ -40,8 +40,8 @@ fn main() {
     App::new()
         .insert_resource(PkvStore::new("BevyPkv", "EnumExample"))
         .add_plugins(MinimalPlugins)
-        .add_plugin(LogPlugin::default())
-        .add_startup_system(setup)
+        .add_plugins(LogPlugin::default())
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/migration.rs
+++ b/examples/migration.rs
@@ -65,7 +65,7 @@ fn main() {
     App::new()
         .insert_resource(PkvStore::new("BevyPkv", "MigrationExample"))
         .add_plugins(MinimalPlugins)
-        .add_plugin(LogPlugin::default())
-        .add_startup_system(setup)
+        .add_plugins(LogPlugin::default())
+        .add_systems(Startup, setup)
         .run();
 }


### PR DESCRIPTION
Not sure if you have any more elaborate system for upgrading, so I just merged the `bevy-main` branch, set Cargo.toml to the version instead of tracking the repository, and fixed some build warnings.