### PR TITLE
Fix PkvStore::get not returning NotFound on empty db

### DIFF
--- a/src/redb_store.rs
+++ b/src/redb_store.rs
@@ -60,6 +60,11 @@ impl ReDbStore {
             .expect("Failed to create directory to init key value store");
         let db_path = dir_path.join("bevy_pkv.redb");
         let db = Database::create(db_path).expect("Failed to init key value store");
+
+        let write_txn = db.begin_write().unwrap();
+        write_txn.open_table(TABLE).unwrap();
+        write_txn.commit().unwrap();
+
         Self { db }
     }
 }


### PR DESCRIPTION
Previously when doing `PkvStore::get `on just created (empty) database would return internal redb table error instead of `GetError::NotFound`. This behavior is not consistent with all the other backends which return `GetError::NotFound`. The error that gets returned is `GetError::ReDbTableError(redb::TableError::TableDoesNotExist(_))`.

`redb` returns this error as it does not create tables when calling `open_table` on read transactions, it creates tables only when calling `open_table` on write transactions.

The two workarounds are:
- Do not handle `Err` variant when doing `PkvStore::get` and just handle `Ok` variant
- Write to database first, before doing any reads

This forces users of `bevy_pkv` to add explicit dependency on `redb` if they want to handle this error.

The solution is to create the table beforehand when creating database.
