### PR TITLE
Test that getting from an empty db returns `NotFound` error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ redb = { version = "1.0.1", optional = true }
 [dev-dependencies]
 bevy = { version = "0.12", default-features = false }
 strum_macros = "0.25"
+tempfile = "3"
 
 [build-dependencies]
 cfg_aliases = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,22 @@ mod tests {
         assert_eq!(ret.unwrap(), "goodbye_custom_path");
     }
 
+    #[cfg(any(sled_backend, rocksdb_backend, redb_backend))]
+    #[test]
+    fn empty_db_not_found() {
+        use crate::GetError;
+
+        setup();
+
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let store = PkvStore::new_in_dir(dir.path());
+
+        let err = store.get::<String>("not_there").unwrap_err();
+
+        // todo: Use assert_matches! when stable
+        assert!(matches!(err, GetError::NotFound));
+    }
+
     #[test]
     fn clear() {
         setup();


### PR DESCRIPTION
Adds a test for #46 