### PR TITLE
Actually working wasm storage clear

### DIFF
--- a/src/local_storage_store.rs
+++ b/src/local_storage_store.rs
@@ -90,7 +90,7 @@ impl StoreImpl for LocalStorageStore {
         let storage = self.storage();
         let length = storage.length().map_err(SetError::Clear)?;
         let prefix = &self.prefix;
-        for index in 0..length {
+        for index in (0..length).rev() {
             if let Some(key) = storage.key(index).map_err(SetError::Clear)? {
                 if key.starts_with(prefix) {
                     storage.remove_item(&key).map_err(SetError::Clear)?;


### PR DESCRIPTION
The problem with wasm key deletion was also a shifting index. https://github.com/johanhelsing/bevy_pkv/blob/main/src/local_storage_store.rs#L96 was being called when the index was moved so any prior key deletions would mess up the index.
I switched to the much simpler `clear` api and made sure it was working on my bevy wasm project.

I should have tested https://github.com/johanhelsing/bevy_pkv/pull/56 more.